### PR TITLE
FEATURE(blackbox-exporter): Control Blackbox Exporter state at boot

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ All variables which can be overridden are stored in [defaults/main.yml](defaults
 | `blackbox_exporter_web_listen_address` | 0.0.0.0:9115 | Address on which blackbox exporter will be listening |
 | `blackbox_exporter_cli_flags` | {} | Additional configuration flags passed to blackbox exporter binary at startup |
 | `blackbox_exporter_configuration_modules` | http_2xx: { prober: http, timeout: 5s, http: '' } | |
+| `blackbox_exporter_systemd_enabled` | true | |
 
 ## Example
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -59,3 +59,5 @@ blackbox_exporter_configuration_modules:
 #      preferred_ip_protocol: ip6
 #      validate_answer_rrs:
 #        fail_if_matches_regexp: [test]
+
+blackbox_exporter_systemd_enabled: true

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -21,6 +21,6 @@
     daemon_reload: true
     name: blackbox_exporter
     state: started
-    enabled: true
+    enabled: "{{ blackbox_exporter_systemd_enabled }}"
   tags:
     - blackbox_exporter_run


### PR DESCRIPTION
 ##### SUMMARY
Add a variable to control Blackbox Exporter state at boot.
By default, Blackbox Exporter is enabled at boot.

 ##### IMPACT
N/A